### PR TITLE
Set STATIC_ROOT/STATIC_URL overrides only if defined in settings.

### DIFF
--- a/wkhtmltopdf/views.py
+++ b/wkhtmltopdf/views.py
@@ -153,12 +153,15 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
             {
             'root': settings.MEDIA_ROOT,
             'url': settings.MEDIA_URL,
-            },
-            {
-            'root': settings.STATIC_ROOT,
-            'url': settings.STATIC_URL,
             }
         ]
+        if settings.STATIC_ROOT:
+            overrides.append(
+                {
+                'root': settings.STATIC_ROOT,
+                'url': settings.STATIC_URL,
+                }
+            )
         has_scheme = re.compile(r'^[^:/]+://')
 
         for x in overrides:


### PR DESCRIPTION
If the project is not yet using staticfiles app, setting file name overrides based on STATIC_ROOT/STATIC_URL settings will cause issues.
