### PR TITLE
Removed extra slashes so the local file paths work in Windows.

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -6,6 +6,7 @@ from itertools import chain
 import os
 import sys
 import urllib
+from urlparse import urljoin
 
 from django.conf import settings
 
@@ -119,4 +120,4 @@ def http_quote(string):
 
 def pathname2fileurl(pathname):
     """Returns a file:// URL for pathname. Handles OS-specific conversions."""
-    return 'file://' + urllib.pathname2url(pathname)
+    return urljoin('file:', urllib.pathname2url(pathname))


### PR DESCRIPTION
Currently there will be five slashes after "file:" in the local file URLs. This won't work in Windows.
