### PR TITLE
Fix for case when WKHTMLTOPDF_CMD consists of many parts.

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -79,7 +79,7 @@ def wkhtmltopdf(pages, output=None, **kwargs):
         env = dict(os.environ, **env)
 
     cmd = getattr(settings, 'WKHTMLTOPDF_CMD', 'wkhtmltopdf')
-    args = list(chain([cmd],
+    args = list(chain(cmd.split(),
                       _options_to_args(**options),
                       list(pages),
                       [output]))


### PR DESCRIPTION
I wanted to use xvfb-run to run the wkhtmltopdf without the hacked Qt version and without X server. Then one needs to set WKHTMLTOPDF_CMD = 'xvfb-run wkhtmltopdf'. This works properly with this fix and same way as earlier for the normal case.
