### PR TITLE
fixed empty URLs

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -147,6 +147,9 @@ def make_absolute_paths(content):
         if not x['root'].endswith('/'):
             x['root'] += '/'
 
+        if x['url'] is '':
+            continue
+
         occur_pattern = '''["|']({0}.*?)["|']'''
         occurences = re.findall(occur_pattern.format(x['url']), content)
         occurences = list(set(occurences))  # Remove dups


### PR DESCRIPTION
'I've spent 4 hours trying to figure out why the generated PDF does not consider CSS rules.

Well, I found out (by looking into the `/tmp` directory) that everything in brackets got replaced with `file://<previouscontent>`. That meant no CSS would get applied.

Then I figured that it was because of the fact that my MEDIA_URL was empty and thus the regex that looks for the links tried to prepend everything inbrackets with `file://`. 

This pull request tries to fix this behaviour and save the mankind some human hours. 
