### PR TITLE
Allow setting multiple cookies

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -21,6 +21,10 @@ def _options_to_args(**options):
         value = options[name]
         if value is None:
             continue
+        if name == 'cookie' and hasattr(value, 'iteritems'):
+            for key, data in value.iteritems():
+                flags.extend(['--cookie', key, data])
+            continue
         flags.append('--' + name.replace('_', '-'))
         if value is not True:
             flags.append(unicode(value))


### PR DESCRIPTION
To set multiple cookies with wkhtmltopdf you pass it multiple
--cookie arguments. As we can't pass multiple kwargs in Python
I have added the ability to set cookie to a dict. In django we
can now just pass request.COOKIES.
