### PR TITLE
Revert some new features to improve robustness (three parts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,6 @@ release:
 	python setup.py register sdist upload
 
 test:
-	PYTHONPATH=.:$$PYTHONPATH; django-admin.py test tests --settings=wkhtmltopdf.test_settings
+	PYTHONPATH=.:$$PYTHONPATH; \
+	    export PYTHONPATH; \
+	    django-admin.py test tests --settings=wkhtmltopdf.test_settings

--- a/README.rst
+++ b/README.rst
@@ -39,11 +39,12 @@ e.g.: in ``settings.py``::
     WKHTMLTOPDF_CMD = '/path/to/my/wkhtmltopdf'
 
 You may also set
-``WKHTMLTOPDF_CMD_OPTIONS``
-in ``settings.py`` to a dictionary of default command-line options.
+``WKHTMLTOPDF_CMD_ARGS``
+in ``settings.py`` to a list of default command-line options.
 
 The default is::
 
-    WKHTMLTOPDF_CMD_OPTIONS = {
-        'quiet': True,
-    }
+    WKHTMLTOPDF_CMD_ARGS = [
+        '--encoding', 'utf8',
+        '--quiet',
+    ]

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -18,14 +18,15 @@ The name of the ``wkhtmltopdf`` binary.
 If there are no path components,
 this app will look for the binary using the default OS paths.
 
-WKHTMLTOPDF_CMD_OPTIONS
+.. _WKHTMLTOPDF-CMD-ARGS:
+
+WKHTMLTOPDF_CMD_ARGS
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``{'encoding': 'utf8', 'quiet': True}``
+Default: ``['--encoding', 'utf8', '--quiet']``
 
-A dictionary of command-line arguments to pass to the ``wkhtmltopdf``
+A list of command-line arguments to pass to the ``wkhtmltopdf``
 binary.
-Keys are the name of the flag and values are arguments for the flag.
 
 To pass a simple flag,
 for example:
@@ -33,7 +34,7 @@ for example:
 
 .. code-block:: python
 
-    WKHTMLTOPDF_CMD_OPTIONS = {'disable-javascript': True}
+    WKHTMLTOPDF_CMD_ARGS = ['--disable-javascript']
 
 To pass a flag with an argument,
 for example:
@@ -41,7 +42,7 @@ for example:
 
 .. code-block:: python
 
-    WKHTMLTOPDF_CMD_OPTIONS = {'title': 'TPS Report'}
+    WKHTMLTOPDF_CMD_ARGS = ['--title', 'TPS Report']
 
 
 WKHTMLTOPDF_DEBUG

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -21,12 +21,12 @@ this app will look for the binary using the default OS paths.
 .. _WKHTMLTOPDF-CMD-ARGS:
 
 WKHTMLTOPDF_CMD_ARGS
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Default: ``['--encoding', 'utf8', '--quiet']``
 
-A list of command-line arguments to pass to the ``wkhtmltopdf``
-binary.
+A default list of command-line arguments
+to pass to the ``wkhtmltopdf`` binary.
 
 To pass a simple flag,
 for example:
@@ -43,6 +43,17 @@ for example:
 .. code-block:: python
 
     WKHTMLTOPDF_CMD_ARGS = ['--title', 'TPS Report']
+
+.. note::
+
+    Since you may pass multiple options to ``wkhtmltopdf``,
+    these default arguments are always passed in when it is run.
+    If you want full control over the arguments used, make sure
+    to pass in an empty list:
+
+    .. code-block:: python
+
+        WKHTMLTOPDF_CMD_ARGS = []
 
 
 WKHTMLTOPDF_DEBUG

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,10 +36,10 @@ It accepts the following class attributes:
     See note below.
     Default is :py:class:`TemplateResponse`.
 
-:py:attr:`cmd_options`
-    The dictionary of command-line arguments passed to the underlying
+:py:attr:`cmd_args`
+    The list of command-line arguments passed to the underlying
     ``wkhtmltopdf`` binary.
-    Default is ``{}``.
+    Default is controlled by :ref:`WKHTMLTOPDF-CMD-ARGS`.
 
     wkhtmltopdf options can be found by running ``wkhtmltopdf --help``.
     Unfortunately they don't provide hosted documentation.
@@ -86,9 +86,10 @@ and override the sections you need to.
     class MyPDF(PDFTemplateView):
         filename = 'my_pdf.pdf'
         template_name = 'my_template.html'
-        cmd_options = {
-            'margin-top': 3,
-        }
+        cmd_args = [
+            '--margin-top', '3',
+            '--quiet',
+        ]
 
 
 Templates

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,7 +1,7 @@
 Usage
 =====
 
-The :py:class:`PDFTemplateView` is a Django class-based view.
+The :py:class:`PDFTemplateView` is a `Django class-based template view`_.
 By default, it uses :py:class:`PDFTemplateResponse` to render an HTML
 template to PDF.
 It accepts the following class attributes:
@@ -49,6 +49,8 @@ It accepts the following class attributes:
     For convenience in development you can add the GET arg ``?as=html`` to the
     end of your URL to render the PDF as a web page.
 
+.. _Django class-based template view: https://docs.djangoproject.com/en/dev/ref/class-based-views/base/#templateview
+
 
 Simple Example
 --------------
@@ -88,11 +90,173 @@ and override the sections you need to.
             'margin-top': 3,
         }
 
+
+Templates
+---------
+
+:py:class:`PDFTemplateView` uses the standard Django templating
+language to turn templated HTML into PDFs.
+
+Remember, you must not hard-code
+``{{ MEDIA_URL }}`` or ``{{ STATIC_URL }}`` in your templates.
+By default,
+Django has ``TEMPLATE_CONTEXT_PROCESSORS``
+that provides these context variables.
+Ensure that you have the following in your ``settings.py`:
+
+.. code-block:: python
+
+    TEMPLATE_CONTEXT_PROCESSORS = [
+        # ...
+        'django.core.context_processors.media',
+        'django.core.context_processors.static',
+        # ...
+    ],
+
+:py:class:`PDFTemplateView` substitutes those settings at render-time
+with ``file://`` paths that point to
+``settings.MEDIA_ROOT`` and ``settings.STATIC_ROOT`` respectively.
+This will set the appropriate context variables
+so that ``wkhtmltopdf`` can load them.
+
+**Incorrect**:
+
+.. code-block:: html
+
+    <html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
+      <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>My Report</title>
+        <script type="text/javascript" src="/static/report.js"></script>     <!-- BAD -->
+        <link rel="stylesheet" type="text/css" href="/static/report.css" />  <!-- BAD -->
+      </head>
+      <body>...</body>
+    </html>
+
+**Correct**:
+
+.. code-block:: html
+
+    <html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
+      <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>My Report</title>
+        <script type="text/javascript" src="{{ STATIC_URL }}report.js"></script>     <!-- Good! -->
+        <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}report.css" />  <!-- Good! -->
+      </head>
+      <body>...</body>
+    </html>
+
+
+
+Overriding other settings
+-------------------------
+
+You may need to add additional overrides to support other Django apps.
+For instance, django-compressor requires that ``settings.COMPRESS_URL``
+matches your ``settings.STATIC_URL``.
+
+To accommodate this, you can add additional settings to override:
+
+.. code-block:: python
+
+    from wkhtmltopdf.views import PDFTemplateResponse, PDFTemplateView
+
+
+    class MyPDFResponse(PDFTemplateResponse):
+        # Make COMPRESS_URL match STATIC_URL
+        default_override_settings = PDFTemplateResponse.default_override_settings.copy()
+        default_override_settings['COMPRESS_URL'] = default_override_settings['STATIC_URL']
+
+
+    class MyPDFView(PDFTemplateView):
+        response_class = MyPDFResponse
+
+Then, use ``MyPDFView`` as the base class for your other PDF views.
+
+
+Hardcoded paths
+---------------
+
+In some templates,
+you may have URLs that have been hardcoded,
+yet cannot use context variables.
+This may happen when you use
+third-party Django apps or templates
+that ignore Django best-practises.
+
+To workaround this problem,
+you can try to manually replace the offending URLs:
+
+.. code-block:: python
+
+    import os
+    import re
+
+    from django.conf import settings
+
+    from wkhtmltopdf.utils import pathname2fileurl
+    from wkhtmltopdf.views import PDFTemplateResponse, PDFTemplateView
+
+
+    class MyPDFResponse(PDFTemplateResponse):
+        # Don't override any settings
+        default_override_settings = {}
+
+        # Override pre_render to replace the URLs
+        def pre_render(self, content, template_name, context):
+            def repl(match):
+                # Replace match with the appropriate file URL
+                url = match.group('url')
+                if url.startswith(settings.STATIC_URL):
+                    path = url.replace(settings.STATIC_URL, settings.STATIC_ROOT, 1)
+                elif url.startswith(settings.MEDIA_URL):
+                    path = url.replace(settings.MEDIA_URL, settings.MEDIA_ROOT, 1)
+                # Add more replacements, if necessary...
+                else:
+                    return match.group(0)
+                return match.group('begin') + pathname2fileurl(path) + match.group('end')
+
+            # Match URL in an attribute
+            content = re.sub(
+                r'(?P<begin>=\s*(?P<quote>["\']))'  # Begins with =" or ='
+                r'(?P<url>/.*?)'                    # URL
+                r'(?P<end>(?P=quote))',             # Ends with matching quote
+                repl, content
+            )
+            content = re.sub(
+                r'(?P<begin>=\s*)'  # Begins with =
+                r'(?P<url>/.*?)'    # URL
+                r'(?P<end>[\s>]|$)',  # Ends with space or end of file
+                repl, content
+            )
+            # Match CSS url()
+            content = re.sub(
+                r'(?P<begin>url\(\s*(?P<quote>["\']?))'  # Begins with url(
+                r'(?P<url>/.*?)'                         # URL
+                r'(?P<end>(?P=quote)\))',                # Ends with closing )
+                repl, content
+            )
+
+            return content
+
+
+    class MyPDFView(PDFTemplateView):
+        response_class = MyPDFResponse
+
+.. note::
+    That this method is fragile and prone to break,
+    because it relies on regular expressions
+    to guess at the URLs to replace.
+
+    **Do not rely on this in the long-term.**
+
+
 Unicode characters
 ------------------
 
-Templates containing utf-8 characters should be supported. You will need to
-ensure that you set the content type in your template file for `wkhtmltopdf` to
+Templates containing UTF-8 characters should be supported. You will need to
+ensure that you set the Content-Type in your template file for `wkhtmltopdf` to
 interpret it properly.
 
 .. code-block:: html

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -209,9 +209,9 @@ you can try to manually replace the offending URLs:
             def repl(match):
                 # Replace match with the appropriate file URL
                 url = match.group('url')
-                if url.startswith(settings.STATIC_URL):
+                if settings.STATIC_URL and url.startswith(settings.STATIC_URL):
                     path = url.replace(settings.STATIC_URL, settings.STATIC_ROOT, 1)
-                elif url.startswith(settings.MEDIA_URL):
+                elif settings.MEDIA_URL and url.startswith(settings.MEDIA_URL):
                     path = url.replace(settings.MEDIA_URL, settings.MEDIA_ROOT, 1)
                 # Add more replacements, if necessary...
                 else:

--- a/wkhtmltopdf/tests/templates/footer.html
+++ b/wkhtmltopdf/tests/templates/footer.html
@@ -1,3 +1,4 @@
 <script src="{{ STATIC_URL }}sample_js_not_existing.js"></script>
 
-<img src="{{ MEDIA_URL }}sample_image_not_existing.png" />
+<img src="{{ MEDIA_URL }}sample_image_not_existing.png"
+     alt="/media/sample_image_not_existing.png does not exist"/>

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -81,7 +81,7 @@ def wkhtmltopdf(pages, output=None, **kwargs):
         env = dict(os.environ, **env)
 
     cmd = getattr(settings, 'WKHTMLTOPDF_CMD', 'wkhtmltopdf')
-    args = list(chain(cmd.split(),
+    args = list(chain([cmd],
                       _options_to_args(**options),
                       list(pages),
                       [output]))

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -64,22 +64,23 @@ def wkhtmltopdf(pages, output=None, cmd_args=None, **kwargs):
 
     cmd_args = list(cmd_args) if cmd_args is not None else []
 
+    # Default arguments:
+    cmd_args = getattr(settings, 'WKHTMLTOPDF_CMD_ARGS', ['--quiet']) + cmd_args
+
     # Parse out deprecated settings variable and arguments
     if kwargs:
         warn('Call wkhtmltopdf with cmd_args instead of calling with **kwargs',
              RuntimeWarning, 2)
         return
+
     options = getattr(settings, 'WKHTMLTOPDF_CMD_OPTIONS', None)
     if options is not None:
         warn('Set WKHTMLTOPDF_CMD_ARGS instead of WKHTMLTOPDF_CMD_OPTIONS',
              RuntimeWarning)
-        kwargs.update(**kwargs)
+        for k, v in options:
+            kwargs.setdefault(k, v)
     if kwargs:
-        cmd_args.extend(_options_to_args(**options))
-
-    # Default arguments:
-    if not cmd_args:
-        cmd_args.extend(getattr(settings, 'WKHTMLTOPDF_CMD_ARGS', ['--quiet']))
+        cmd_args.extend(_options_to_args(**kwargs))
 
     # Force --encoding utf8 unless the user has explicitly overridden this.
     if '--encoding' not in cmd_args:

--- a/wkhtmltopdf/views.py
+++ b/wkhtmltopdf/views.py
@@ -36,6 +36,13 @@ class PDFResponse(HttpResponse):
                 fileheader = 'inline; filename={0}'
 
             filename = content_disposition_filename(filename)
+
+            # Because unidecode will simply discard characters it cannot
+            # replace, we need to make sure the filename actually has one
+            # character at least.
+            if filename.startswith('".'):
+                filename = '"?%s' % filename[1:]
+
             header_content = fileheader.format(filename)
             self['Content-Disposition'] = header_content
         else:


### PR DESCRIPTION
## Revert "Fix for case when WKHTMLTOPDF_CMD consists of many parts."

WKHTMLTOPDF_CMD may contain whitespace as part of its filename.
To add extra command-line options, set them in WKHTMLTOPDF_CMD_OPTIONS.

This reverts commit 5792a92b237c2cc5409fab4ab6c1e8078adf44d2.
## Revert "Merge pull request #18 from incuna/images-fixed"

Restore use of override_settings, with a small fix to its import for
Django 1.4+.

override_settings is the correct way to substitute relative paths for
file:// URLs when rendering locally. Blind regexp matches have too
many false positives to be reliable.

This reverts commit 18db05d, reversing
changes made to cf4bd17.

Conflicts:
    wkhtmltopdf/utils.py
    wkhtmltopdf/views.py
## Replace WKHTMLTOPDF_CMD_OPTIONS with WKHTMLTOPDF_CMD_ARGS.

As well, wkhtmltopdf() takes cmd_args as a parameter, warning if
**kwargs is used instead.

This allows users to specify more than one version of each option. For
instance, it is now possible to pass in multiple --cookie parameters,
which has two arguments.
