### PR TITLE
Ignore non-ascii characters in call to `make_absolute_paths`

### DIFF
--- a/wkhtmltopdf/views.py
+++ b/wkhtmltopdf/views.py
@@ -75,7 +75,7 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
         context = self.resolve_context(self.context_data)
 
         content = smart_str(template.render(context))
-        content = make_absolute_paths(content)
+        content = make_absolute_paths(unicode(content, 'ascii', 'ignore'))
 
         tempfile = NamedTemporaryFile(mode=mode, bufsize=bufsize,
                                       suffix=suffix, prefix=prefix,


### PR DESCRIPTION
Ignore non-ascii characters in call to `make_absolute_paths`.  This is required to prevent `make_absolute_paths` from raising an exception when it encounters values it can't properly convert.