### PR TITLE
Fix utf-8 encoding in views.py to render Unicode characters to PDF

### DIFF
--- a/wkhtmltopdf/views.py
+++ b/wkhtmltopdf/views.py
@@ -86,7 +86,7 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
                                           dir=dir, delete=delete)
 
         try:
-            tempfile.write(content.encode('utf-8'))
+            tempfile.write(content)
             tempfile.flush()
             return tempfile
         except:


### PR DESCRIPTION
Hello, I found a bug and I believe that as the commit ef5678ce4ff518b7e3dfbda87563b7ffac6d7816 was set as the default, is the cause of the problem. It worked for me and hope it works for others: D. 
Thanks!