### PR TITLE
Add option WKHTMLTOPDF_MAKE_ABS_PATHS

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -67,3 +67,14 @@ when using ``wkhtmltopdf --use-xserver``:
 .. code-block:: python
 
     WKHTMLTOPDF_ENV = {'DISPLAY': ':2'}
+
+
+WKHTMLTOPDF_MAKE_ABS_PATHS
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``True``
+
+A boolean that turns on/off converting all MEDIA files into a 'file://URL' paths
+in order to get it displayed in PDFs.
+You may want to disable it for manual paths management.
+

--- a/wkhtmltopdf/views.py
+++ b/wkhtmltopdf/views.py
@@ -73,7 +73,9 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
         context = self.resolve_context(self.context_data)
 
         content = smart_text(template.render(context))
-        content = make_absolute_paths(content)
+        
+        if getattr(settings, 'WKHTMLTOPDF_MAKE_ABS_PATHS', True):
+            content = make_absolute_paths(content)
 
         try:
             # Python3 has 'buffering' arg instead of 'bufsize'


### PR DESCRIPTION
I've added option to disable  paths converting to 'file://URL'. I want manage paths manually. And second reason is because `make_absolute_paths` doesn't work for me. Here is example of what I've get in compiled template after converting:
```html
<!-- page file:///1 -->
<div class="file:///virtual-page">
  <!-- header -->
  <header class="file:///virtual-header">
  <h4 class="file:///header-title">Audience Delivery Report</h4>
  <h4 class="file:///header-daterange">January 2file:///0file:///15</h4>
  <svg width="file:///8file:///12px" height="6file:///0px">
    <g transform="file:///scale(file:///1.3)">
```
Tested manually. I'll add unittests soon.