### PR TITLE
added the WKHTMLTOPDF_MAKE_ABSOLUTE_PATHS option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,13 @@ The default is: ::
         'quiet': True,
     }
 
+Paths in the HTML will be automatically converted to absolute.
+This can be configured via ``WKHTMLTOPDF_CMD_OPTIONS`` in ``settings.py``
+The default is: ::
+
+    WKHTMLTOPDF_MAKE_ABSOLUTE_PATHS = True
+
+
 License
 -------
 

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -152,7 +152,7 @@ def make_absolute_paths(content):
     has_scheme = re.compile(r'^[^:/]+://')
 
     for x in overrides:
-        if has_scheme.match(x['url']):
+        if not x['url'] or has_scheme.match(x['url']):
             continue
 
         if not x['root'].endswith('/'):

--- a/wkhtmltopdf/views.py
+++ b/wkhtmltopdf/views.py
@@ -73,7 +73,9 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
         context = self.resolve_context(self.context_data)
 
         content = smart_text(template.render(context))
-        content = make_absolute_paths(content)
+
+        if getattr(settings, 'WKHTMLTOPDF_MAKE_ABSOLUTE_PATHS', True):
+            content = make_absolute_paths(content)
 
         try:
             # Python3 has 'buffering' arg instead of 'bufsize'


### PR DESCRIPTION
I had some `CalledProcessError` and a bunch of "file:///" strings (e.g. attachment).
I have forked this project a few months ago because of that and spent the last 8 hours finding how I had solved that as I'm having the same issue on a new django 1.7 project and I had forgotten about that fok.

Hope to see it merged some day not to get trapped again ;)

![screen shot 2015-01-29 at 3 40 23 pm](https://cloud.githubusercontent.com/assets/145172/5966818/2e912e84-a7cd-11e4-85c0-4cf99f8e679c.png)

