### PR TITLE
use updated URL for wkhtmltopdf 0.12.2.1 in the travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ before_install:
   - PWD=`pwd`
   - "echo '## Installing dependencies'"
   - "sudo apt-get update"
-  - "sudo apt-get install -y openssl build-essential xorg libssl-dev"
-  - "echo '## Downloading wkhtmltopdf 0.12.1'"
-  - "wget http://freefr.dl.sourceforge.net/project/wkhtmltopdf/0.12.1/wkhtmltox-0.12.1_linux-precise-amd64.deb"
+  - "sudo apt-get install -y openssl build-essential xorg libssl-dev xfonts-base xfonts-75dpi"
+  - "echo '## Downloading wkhtmltopdf 0.12.2.1'"
+  - "wget http://freefr.dl.sourceforge.net/project/wkhtmltopdf/0.12.2.1/wkhtmltox-0.12.2.1_linux-precise-amd64.deb"
   - "echo '## Installing wkhtmltox'"
-  - "sudo dpkg -i wkhtmltox-0.12.1_linux-precise-amd64.deb"
+  - "sudo dpkg -i wkhtmltox-0.12.2.1_linux-precise-amd64.deb"
   - WHICH_WK=`which wkhtmltopdf`
   - "export WKHTMLTOPDF_CMD=$WHICH_WK"
 install:


### PR DESCRIPTION
The earlier URL is no longer available.