### PR TITLE
Skip absolute path substitution where STATIC or MEDIA URL are empty or None

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -152,7 +152,7 @@ def make_absolute_paths(content):
     has_scheme = re.compile(r'^[^:/]+://')
 
     for x in overrides:
-        if has_scheme.match(x['url']):
+        if not x['url'] or has_scheme.match(x['url']):
             continue
 
         if not x['root'].endswith('/'):

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -93,8 +93,13 @@ def wkhtmltopdf(pages, output=None, **kwargs):
                          list(pages),
                          [output]))
     ck_kwargs = {'env': env}
-    if hasattr(sys.stderr, 'fileno'):
+    try:
+        i = sys.stderr.fileno()
         ck_kwargs['stderr'] = sys.stderr
+    except AttributeError:
+        # can't call fileno() on mod_wsgi stderr object
+        pass
+
     return check_output(ck_args, **ck_kwargs)
 
 


### PR DESCRIPTION
STATIC_URL or MEDIA_URL settings default to None or empty string
These default values cause the url match and replace algorithm to insert the *_ROOT setting in EVERY quoted string!!
This is the same bug reported in #57, but this patch fixes both STATIC and MEDIA URLs
I think a proper patch for this bug obviates the need for a special setting to make this method optional, as suggested in #74