### PR TITLE
Enable tests to run with Django >= 1.7 and silence warnings

### DIFF
--- a/wkhtmltopdf/tests/run.py
+++ b/wkhtmltopdf/tests/run.py
@@ -2,10 +2,12 @@
 import os
 import sys
 
+import django
 from django.conf import settings
 
 DIRNAME = os.path.abspath(os.path.dirname(__file__))
 
+sys.path.insert(0, os.getcwd())
 
 settings.configure(
     DEBUG=True,
@@ -19,12 +21,22 @@ settings.configure(
         'wkhtmltopdf.tests',
         'wkhtmltopdf',
     ),
+    MIDDLEWARE_CLASSES=(
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+    ),
     MEDIA_ROOT=os.path.join(DIRNAME, 'media'),
     MEDIA_URL='/media/',
     STATIC_ROOT=os.path.join(DIRNAME, 'static'),
     STATIC_URL='/static/',
     WKHTMLTOPDF_DEBUG=True,
 )
+
+try:
+    django.setup()
+except AttributeError:
+    pass  # Django < 1.7; okay to ignore
+
 
 try:
     from django.test.runner import DiscoverRunner


### PR DESCRIPTION
This addresses issue #93, and other related changes needed to get tests running again with recent Django versions.