### PR TITLE
Add catch IOError for fileno() call 

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -94,10 +94,11 @@ def wkhtmltopdf(pages, output=None, **kwargs):
                          list(pages),
                          [output]))
     ck_kwargs = {'env': env}
+    # Handling of fileno() attr. based on https://github.com/GrahamDumpleton/mod_wsgi/issues/85
     try:
         i = sys.stderr.fileno()
         ck_kwargs['stderr'] = sys.stderr
-    except AttributeError:
+    except AttributeError, IOError:
         # can't call fileno() on mod_wsgi stderr object
         pass
 

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -98,7 +98,7 @@ def wkhtmltopdf(pages, output=None, **kwargs):
     try:
         i = sys.stderr.fileno()
         ck_kwargs['stderr'] = sys.stderr
-    except AttributeError, IOError:
+    except (AttributeError, IOError):
         # can't call fileno() on mod_wsgi stderr object
         pass
 


### PR DESCRIPTION
This is the cleanest patch that brings django-wkhtmltopdf in sync with latest versions of mod_wsgi.
Simply added IOError catch to accommodate changes to mod_wsgi v.4.4.14, as detailed here:  https://github.com/GrahamDumpleton/mod_wsgi/issues/85