### PR TITLE
Fix unidecode bytes error on python2

### DIFF
--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -133,11 +133,11 @@ class TestViews(TestCase):
         try:
             import unidecode
         except ImportError:
-            self.assertEqual(response['Content-Disposition'],
-                             'attachment; filename="?.pdf"')
+            filename = '?.pdf'
         else:
-            self.assertEqual(response['Content-Disposition'],
-                             'attachment; filename=".pdf"')
+            filename = '.pdf'
+        self.assertEqual(response['Content-Disposition'],
+                         'attachment; filename="{}"'.format(filename))
 
         # Content as a direct output
         response = PDFResponse(content=content, filename="nospace.pdf",
@@ -157,11 +157,11 @@ class TestViews(TestCase):
         try:
             import unidecode
         except ImportError:
-            self.assertEqual(response['Content-Disposition'],
-                             'inline; filename="?.pdf"')
+            filename = '?.pdf'
         else:
-            self.assertEqual(response['Content-Disposition'],
-                             'inline; filename=".pdf"')
+            filename = '.pdf'
+        self.assertEqual(response['Content-Disposition'],
+                         'attachment; filename="{}"'.format(filename))
 
         # Content-Type
         response = PDFResponse(content=content,

--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -137,7 +137,7 @@ class TestViews(TestCase):
         else:
             filename = '.pdf'
         self.assertEqual(response['Content-Disposition'],
-                         'attachment; filename="{}"'.format(filename))
+                         'attachment; filename="{0}"'.format(filename))
 
         # Content as a direct output
         response = PDFResponse(content=content, filename="nospace.pdf",
@@ -161,7 +161,7 @@ class TestViews(TestCase):
         else:
             filename = '.pdf'
         self.assertEqual(response['Content-Disposition'],
-                         'attachment; filename="{}"'.format(filename))
+                         'inline; filename="{0}"'.format(filename))
 
         # Content-Type
         response = PDFResponse(content=content,

--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -130,8 +130,14 @@ class TestViews(TestCase):
         self.assertEqual(response['Content-Disposition'],
                          'attachment; filename="4\'5.pdf"')
         response = PDFResponse(content=content, filename=u"♥.pdf")
-        self.assertEqual(response['Content-Disposition'],
-                         'attachment; filename="?.pdf"')
+        try:
+            import unidecode
+        except ImportError:
+            self.assertEqual(response['Content-Disposition'],
+                             'attachment; filename="?.pdf"')
+        else:
+            self.assertEqual(response['Content-Disposition'],
+                             'attachment; filename=".pdf"')
 
         # Content as a direct output
         response = PDFResponse(content=content, filename="nospace.pdf",
@@ -148,8 +154,14 @@ class TestViews(TestCase):
                          'inline; filename="4\'5.pdf"')
         response = PDFResponse(content=content, filename=u"♥.pdf",
             show_content_in_browser=True)
-        self.assertEqual(response['Content-Disposition'],
-                         'inline; filename="?.pdf"')
+        try:
+            import unidecode
+        except ImportError:
+            self.assertEqual(response['Content-Disposition'],
+                             'inline; filename="?.pdf"')
+        else:
+            self.assertEqual(response['Content-Disposition'],
+                             'inline; filename=".pdf"')
 
         # Content-Type
         response = PDFResponse(content=content,

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -186,9 +186,11 @@ def http_quote(string):
     if isinstance(string, six.text_type):
         try:
             import unidecode
-            string = bytes(unidecode.unidecode(string), 'ascii')
         except ImportError:
-            string = string.encode('ascii', 'replace')
+            pass
+        else:
+            string = unidecode.unidecode(string)
+        string = string.encode('ascii', 'replace')
     # Wrap in double-quotes for ; , and the like
     string = string.replace(b'\\', b'\\\\').replace(b'"', b'\\"')
     return '"{0!s}"'.format(string.decode())


### PR DESCRIPTION
`bytes` takes no additional args in python2 unlike it's taking
an encoding in python3.

Unidecode returns a unicode string in python3 and a bytestring
in python2 which, I believe, was the main cause of error #71.

Now, regardless of whether unidecode is included, all strings
passing through http_quote will be encoded to ascii which should
fix both issues.

Also included is two fixes for a failing test when unidecode is used.
Unidecode's `_unidecode` function ignores characters greater
than `0xefff`, which `\xe2\x99\xa5` (the heart symbol) is. This
caused users with unidecode to fail '.pdf' was produced rather
than the expected '?.pdf'.