### PR TITLE
Remove dependency on Django template engine

### DIFF
--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -203,7 +203,8 @@ class TestViews(TestCase):
         self.assertTrue(response.has_header('Content-Disposition'))
 
         footer_template = loader.get_template(self.footer_template)
-        tempfile = render_to_temporary_file(footer_template, context=RequestContext(request, context))
+        tempfile = render_to_temporary_file(footer_template, context=context,
+                                            request=request)
         tempfile.seek(0)
         footer_content = smart_str(tempfile.read())
         footer_content = make_absolute_paths(footer_content)

--- a/wkhtmltopdf/views.py
+++ b/wkhtmltopdf/views.py
@@ -75,6 +75,7 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
             self.resolve_template(self.header_template),
             self.resolve_template(self.footer_template),
             context=self.resolve_context(self.context_data),
+            request=self._request,
             cmd_options=cmd_options
         )
 


### PR DESCRIPTION
This is a PR for issue #101.

I've changed the API a bit by passing an optional `request` down to `render_to_temporary_file()` because this is where the template's `render()` method is ultimately called. Note that I assumed Django 1.7 was still supported.

I noticed one of the tests expected context processors to be called. In order to be compatible with the new API introduced in 1.8, the `request` needs to be passed to `render()`. Passing an instance of `Context` or `RequestContext` is deprecated so this needs to be done to ensure context processors are are run in 1.10.

Please let me know if you have any feedback.