### PR TITLE
Refactor to better support multiple pages.

### DIFF
--- a/wkhtmltopdf/tests/run.py
+++ b/wkhtmltopdf/tests/run.py
@@ -9,28 +9,8 @@ DIRNAME = os.path.abspath(os.path.dirname(__file__))
 
 sys.path.insert(0, os.getcwd())
 
-def run_tests():
-    # Utility function to executes tests.
-    # Will be called twice. Once with DEBUG=True and once with DEBUG=False.
-    try:
-        django.setup()
-    except AttributeError:
-        pass  # Django < 1.7; okay to ignore
-
-
-    try:
-        from django.test.runner import DiscoverRunner
-    except ImportError:
-        from discover_runner.runner import DiscoverRunner
-
-
-    test_runner = DiscoverRunner(verbosity=1)
-    failures = test_runner.run_tests(['wkhtmltopdf'])
-    if failures:
-        sys.exit(1)
-
 settings.configure(
-    DEBUG=True,
+    DEBUG=False,
     DATABASES={
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -49,14 +29,22 @@ settings.configure(
     MEDIA_URL='/media/',
     STATIC_ROOT=os.path.join(DIRNAME, 'static'),
     STATIC_URL='/static/',
-    WKHTMLTOPDF_DEBUG=True,
+    WKHTMLTOPDF_DEBUG=False,
 )
 
-# Run tests with True debug settings (persistent temporary files).
-run_tests()
+try:
+    django.setup()
+except AttributeError:
+    pass  # Django < 1.7; okay to ignore
 
-settings.DEBUG = False
-settings.WKHTMLTOPDF_DEBUG = False
 
-# Run tests with False debug settings to test temporary file delete operations.
-run_tests()
+try:
+    from django.test.runner import DiscoverRunner
+except ImportError:
+    from discover_runner.runner import DiscoverRunner
+
+
+test_runner = DiscoverRunner(verbosity=1)
+failures = test_runner.run_tests(['wkhtmltopdf'])
+if failures:
+    sys.exit(1)

--- a/wkhtmltopdf/tests/run.py
+++ b/wkhtmltopdf/tests/run.py
@@ -9,6 +9,26 @@ DIRNAME = os.path.abspath(os.path.dirname(__file__))
 
 sys.path.insert(0, os.getcwd())
 
+def run_tests():
+    # Utility function to executes tests.
+    # Will be called twice. Once with DEBUG=True and once with DEBUG=False.
+    try:
+        django.setup()
+    except AttributeError:
+        pass  # Django < 1.7; okay to ignore
+
+
+    try:
+        from django.test.runner import DiscoverRunner
+    except ImportError:
+        from discover_runner.runner import DiscoverRunner
+
+
+    test_runner = DiscoverRunner(verbosity=1)
+    failures = test_runner.run_tests(['wkhtmltopdf'])
+    if failures:
+        sys.exit(1)
+
 settings.configure(
     DEBUG=True,
     DATABASES={
@@ -32,19 +52,11 @@ settings.configure(
     WKHTMLTOPDF_DEBUG=True,
 )
 
-try:
-    django.setup()
-except AttributeError:
-    pass  # Django < 1.7; okay to ignore
+# Run tests with True debug settings (persistent temporary files).
+run_tests()
 
+settings.DEBUG = False
+settings.WKHTMLTOPDF_DEBUG = False
 
-try:
-    from django.test.runner import DiscoverRunner
-except ImportError:
-    from discover_runner.runner import DiscoverRunner
-
-
-test_runner = DiscoverRunner(verbosity=1)
-failures = test_runner.run_tests(['wkhtmltopdf'])
-if failures:
-    sys.exit(1)
+# Run tests with False debug settings to test temporary file delete operations.
+run_tests()

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -113,8 +113,8 @@ def convert_to_pdf(filename, header_filename=None, footer_filename=None, cmd_opt
     # Clobber header_html and footer_html only if filenames are
     # provided. These keys may be in self.cmd_options as hardcoded
     # static files.
-    # The argument `filename` should be a list. However, wkhtmltopdf will
-    # coerce into a list if a string is passed.
+    # The argument `filename` may be a string or a list. However, wkhtmltopdf
+    # will coerce it into a list if a string is passed.
     cmd_options = cmd_options if cmd_options else {}
 
     if header_filename is not None:
@@ -180,7 +180,7 @@ def render_pdf_from_template(input_template, header_template, footer_template, c
         )
         footer_filename = footer_file.filename
 
-    return convert_to_pdf(filename=[input_file.filename],
+    return convert_to_pdf(filename=input_file.filename,
                           header_filename=header_filename,
                           footer_filename=footer_filename,
                           cmd_options=cmd_options)

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -134,18 +134,14 @@ class RenderedFile(object):
     def __init__(self, template, context, request=None):
         debug = getattr(settings, 'WKHTMLTOPDF_DEBUG', settings.DEBUG)
 
-        try:
-            self.temporary_file = render_to_temporary_file(
-                template=template,
-                context=context,
-                request=request,
-                prefix='wkhtmltopdf', suffix='.html',
-                delete=(not debug)
-            )
-            self.filename = self.temporary_file.name
-        except:
-            # In case something fails, return an empty filename string.
-            self.filename = ''
+        self.temporary_file = render_to_temporary_file(
+            template=template,
+            context=context,
+            request=request,
+            prefix='wkhtmltopdf', suffix='.html',
+            delete=(not debug)
+        )
+        self.filename = self.temporary_file.name
 
     def __del__(self):
         # Always close the temporary_file on object destruction.


### PR DESCRIPTION
## Add Render Flexibility

The purpose of these changes are to make it easier to take advantage of wkhtmltopdf's ability to render multiple pages as a single PDF document.

- I have changed convert_to_pdf to accept a list instead of a string.
- Factored out some repeating logic in render_pdf_from_template.