### PR TITLE
fix issue #117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog for django-wkhtmltopdf
 
 This release is identical to `2.1.0`, but with a major version bump to reflect the backwards-incompatible changes.
 
+* improvement in setup.py to get version and author, without directly import wkhtmltopdf module
+
 2.1.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,38 @@
+import io
+import os
+import re
+import sys
+
 from setuptools import setup, find_packages
 
-import wkhtmltopdf
 
+def get_version_and_author(*file_paths):
+    filename = os.path.join(os.path.dirname(__file__), *file_paths)
+    with open(filename) as a_file:
+        file_content = a_file.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  file_content, re.M)
+        author_match = re.search(r"^__author__ = ['\"]([^'\"]*)['\"]",
+                                 file_content, re.M)
+        if version_match and author_match:
+            return version_match.group(1), author_match.group(1)
+    raise RuntimeError('Unable to find version and/or author string.')
+
+
+VERSION, AUTHOR = get_version_and_author('wkhtmltopdf', '__init__.py')
+
+with io.open('README.rst', encoding='utf8') as readme_file:
+    README = readme_file.read()  # NOQA
 
 setup(
     name='django-wkhtmltopdf',
     packages=find_packages(),
     include_package_data=True,
-    version=wkhtmltopdf.__version__,
+    version=VERSION,
     description='Converts HTML to PDF using wkhtmltopdf.',
-    long_description=open('README.rst').read(),
+    long_description=README,
     license='MIT',
-    author=wkhtmltopdf.__author__,
+    author=AUTHOR,
     author_email='admin@incuna.com',
     url='https://github.com/incuna/django-wkhtmltopdf',
     zip_safe=False,
@@ -31,3 +52,4 @@ setup(
     ],
     keywords='django wkhtmltopdf pdf',
 )
+


### PR DESCRIPTION
indirectly get version and author values from `wkhtmltopdf.__init__.py` to fix problems to install with tox if django is not installed yet.

Fix issue #117 and probably #105 
