### PR TITLE
Update MANIFEST.in to include LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 recursive-include * *.html
+LICENSE

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version=wkhtmltopdf.__version__,
     description='Converts HTML to PDF using wkhtmltopdf.',
     long_description=open('README.rst').read(),
-    license='MIT',
+    license='BSD-2-Clause',
     author=wkhtmltopdf.__author__,
     author_email='admin@incuna.com',
     url='https://github.com/incuna/django-wkhtmltopdf',


### PR DESCRIPTION
Without the LICENSE in the source distribution, end users don't have local access to the license.  I think this is better to include for the same reasons the LICENSE file is in the repository to begin with.