### PR TITLE
Support for Table of Contents

### DIFF
--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -83,6 +83,16 @@ class TestUtils(TestCase):
         finally:
             temp_file.close()
 
+    def test_table_of_contents(self):
+        title = 'Chapter 1'
+        template = loader.get_template('sample.html')
+        temp_file = render_to_temporary_file(template, context={'title': title})
+        try:
+            pdf_output = wkhtmltopdf(pages=[temp_file.name])
+            self.assertTrue(pdf_output.find("Pages 2") > -1)
+        finally:
+            temp_file.close()
+
     def test_wkhtmltopdf_with_unicode_content(self):
         """A wkhtmltopdf call should render unicode content properly"""
         title = u'♥'

--- a/wkhtmltopdf/views.py
+++ b/wkhtmltopdf/views.py
@@ -43,6 +43,7 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
                  filename=None, show_content_in_browser=None,
                  header_template=None, footer_template=None,
                  cmd_options=None, *args, **kwargs):
+        cover_template = kwargs.pop('cover_template', None)
 
         super(PDFTemplateResponse, self).__init__(request=request,
                                                   template=template,
@@ -54,6 +55,7 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
 
         self.header_template = header_template
         self.footer_template = footer_template
+        self.cover_template = cover_template
 
         if cmd_options is None:
             cmd_options = {}
@@ -75,7 +77,8 @@ class PDFTemplateResponse(TemplateResponse, PDFResponse):
             self.resolve_template(self.footer_template),
             context=self.resolve_context(self.context_data),
             request=self._request,
-            cmd_options=cmd_options
+            cmd_options=cmd_options,
+            cover_template=self.resolve_template(self.cover_template)
         )
 
 class PDFTemplateView(TemplateView):
@@ -91,6 +94,7 @@ class PDFTemplateView(TemplateView):
     template_name = None
     header_template = None
     footer_template = None
+    cover_template = None
 
     # TemplateResponse classes for PDF and HTML
     response_class = PDFTemplateResponse
@@ -147,6 +151,7 @@ class PDFTemplateView(TemplateView):
                 header_template=self.header_template,
                 footer_template=self.footer_template,
                 cmd_options=cmd_options,
+                cover_template=self.cover_template,
                 **response_kwargs
             )
         else:


### PR DESCRIPTION
This PR adds support for including a Table of Contents as the first page of a PDF, addressing #12 and possibly #91. Please note it's a pretty major change to how the subprocess is called, so I understand if this is a non-starter, but I wanted to propose it so users wanting support for `toc` can find it. Working for me on OSX and Windows.