### PR TITLE
Allow rendering PDFs when request is None

### DIFF
--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -14,8 +14,8 @@ from django.utils.encoding import smart_str
 
 from wkhtmltopdf.subprocess import CalledProcessError
 from wkhtmltopdf.utils import (_options_to_args, make_absolute_paths,
-                               wkhtmltopdf, render_to_temporary_file,
-                               RenderedFile)
+                               wkhtmltopdf, render_pdf_from_template,
+                               render_to_temporary_file, RenderedFile)
 from wkhtmltopdf.views import PDFResponse, PDFTemplateView, PDFTemplateResponse
 
 
@@ -143,6 +143,18 @@ class TestUtils(TestCase):
             # Then check if file persists when debug=True.
             self.assertTrue(debug)
             self.assertTrue(os.path.isfile(filename))
+
+    def test_render_with_null_request(self):
+        """If request=None, the file should render properly."""
+        title = 'A test template.'
+        template = loader.get_template('sample.html')
+        pdf_content = render_pdf_from_template('sample.html',
+                                               header_template=None,
+                                               footer_template=None,
+                                               context={'title': title})
+
+        self.assertTrue(pdf_content.startswith(b'%PDF-'))
+        self.assertTrue(pdf_content.endswith(b'%%EOF\n'))
 
 
 class TestViews(TestCase):

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -299,13 +299,11 @@ def render_to_temporary_file(template, context, request=None, mode='w+b',
                 context = RequestContext(request, context)
             else:
                 context = Context(context)
+    # Handle error when ``request`` is None
+    try:
         content = template.render(context)
-    else:
-        # Handle error when ``request`` is None
-        try:
-            content = template.render(context, request)
-        except AttributeError:
-            content = loader.render_to_string(template, context)
+    except AttributeError:
+        content = loader.render_to_string(template, context)
 
     content = smart_text(content)
     content = make_absolute_paths(content)


### PR DESCRIPTION
Fixes an error when rendering a PDF with `request=None`. This used to raise the following error:
```
AttributeError: 'str' object has no attribute 'render'
```
This updates `render_to_temporary_file()` to handle a null request and adds a test using `render_pdf_from_template()` with a null request.