### PR TITLE
changed wkhtmltopdf install procedure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - sudo apt-get install xvfb
   - sudo apt-get install wkhtmltopdf
   - WHICH_WK=`which wkhtmltopdf`
-  - export WKHTMLTOPDF_CMD='xvfb-run $WHICH_WK'
+  - export WKHTMLTOPDF_CMD="xvfb-run $WHICH_WK"
 install:
   - pip install $DJANGO
   - pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,13 @@ matrix:
       env: DJANGO="Django>=1.7,<1.8"
 before_install:
   - PWD=`pwd`
-  - echo '## Installing wkhtmltopdf'
-  - sudo add-apt-repository ppa:pov/wkhtmltopdf -y
+  - echo '## Installing wkhtmltopdf dependencies'
   - sudo apt-get update -qq
-  - sudo apt-get install xvfb
-  - sudo apt-get install wkhtmltopdf
-  - WHICH_WK=`which wkhtmltopdf`
-  - export WKHTMLTOPDF_CMD="xvfb-run -a $WHICH_WK"
+  - sudo apt-get install -y libxrender1 libfontconfig1 zlib1g libfreetype6 libx11-6 libxext6
+  - echo '## Installing wkhtmltopdf'
+  - wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
+  - tar xf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
+  - export WKHTMLTOPDF_CMD="$PWD/wkhtmltox/bin/wkhtmltopdf"
 install:
   - pip install $DJANGO
   - pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - sudo apt-get install xvfb
   - sudo apt-get install wkhtmltopdf
   - WHICH_WK=`which wkhtmltopdf`
-  - export WKHTMLTOPDF_CMD="xvfb-run $WHICH_WK"
+  - export WKHTMLTOPDF_CMD="xvfb-run -a $WHICH_WK"
 install:
   - pip install $DJANGO
   - pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,10 @@ before_install:
   - echo '## Installing wkhtmltopdf'
   - sudo add-apt-repository ppa:pov/wkhtmltopdf -y
   - sudo apt-get update -qq
+  - sudo apt-get install xvfb
   - sudo apt-get install wkhtmltopdf
   - WHICH_WK=`which wkhtmltopdf`
-  - export WKHTMLTOPDF_CMD=$WHICH_WK
+  - export WKHTMLTOPDF_CMD=xvfb-run $WHICH_WK
 install:
   - pip install $DJANGO
   - pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - sudo apt-get install xvfb
   - sudo apt-get install wkhtmltopdf
   - WHICH_WK=`which wkhtmltopdf`
-  - export WKHTMLTOPDF_CMD=xvfb-run $WHICH_WK
+  - export WKHTMLTOPDF_CMD='xvfb-run $WHICH_WK'
 install:
   - pip install $DJANGO
   - pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,15 +42,12 @@ matrix:
       env: DJANGO="Django>=1.7,<1.8"
 before_install:
   - PWD=`pwd`
-  - "echo '## Installing dependencies'"
-  - "sudo apt-get update"
-  - "sudo apt-get install -y openssl build-essential xorg libssl-dev xfonts-75dpi"
-  - "echo '## Downloading wkhtmltopdf'"
-  - "wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-wheezy-amd64.deb"
-  - "echo '## Installing wkhtmltox'"
-  - "sudo dpkg -i wkhtmltox-0.12.2.1_linux-wheezy-amd64.deb"
+  - echo '## Installing wkhtmltopdf'
+  - sudo add-apt-repository ppa:pov/wkhtmltopdf -y
+  - sudo apt-get update -qq
+  - sudo apt-get install wkhtmltopdf
   - WHICH_WK=`which wkhtmltopdf`
-  - "export WKHTMLTOPDF_CMD=$WHICH_WK"
+  - export WKHTMLTOPDF_CMD=$WHICH_WK
 install:
   - pip install $DJANGO
   - pip install -r test_requirements.txt


### PR DESCRIPTION
The GNA.org servers were shut down earlier this year. This commit changes the `before_install` procedure and instead downloads the package from Github releases of wkhtmltopdf. It will make it easier for new PR's to continue the CI tests.