### PR TITLE
Avoid non existing STATIC_ROOT

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -284,7 +284,8 @@ def make_absolute_paths(content):
             'url': settings.MEDIA_URL,
         },
         {
-            'root': settings.STATIC_ROOT if not settings.DEBUG else settings.STATICFILES_DIRS[0],
+            'root': settings.STATIC_ROOT if not settings.DEBUG else settings.STATICFILES_DIRS[0] if len(
+                settings.STATICFILES_DIRS)>0 else '',
             'url': settings.STATIC_URL,
         }
     ]

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -284,7 +284,7 @@ def make_absolute_paths(content):
             'url': settings.MEDIA_URL,
         },
         {
-            'root': settings.STATIC_ROOT,
+            'root': settings.STATIC_ROOT if not settings.DEBUG else settings.STATICFILES_DIRS[0],
             'url': settings.STATIC_URL,
         }
     ]


### PR DESCRIPTION
When Django DEBUG mode is on, I get an error because in the debug mode there is no STATIC_ROOT setting.
In the proposed changes I made a workaround of this issue.