### PR TITLE
Switch from django.utils.six to python six (for Django 3.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,7 @@ setup(
         'Framework :: Django',
     ],
     keywords='django wkhtmltopdf pdf',
+    install_requires=[
+        'six',
+    ],
 )

--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -10,8 +10,8 @@ from django.template import loader, RequestContext
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.test.client import RequestFactory
-from django.utils import six
 from django.utils.encoding import smart_str
+import six
 
 from wkhtmltopdf.subprocess import CalledProcessError
 from wkhtmltopdf.utils import (_options_to_args, make_absolute_paths,

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -21,7 +21,7 @@ import django
 from django.conf import settings
 from django.template import loader
 from django.template.context import Context, RequestContext
-from django.utils import six
+import six
 
 from .subprocess import check_output
 


### PR DESCRIPTION
[Django 3.0 removes `django.utils.six`](https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis). Closes #168.