### PR TITLE
Support PosixPath for MEDIA_ROOT and STATIC_ROOT

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -293,15 +293,16 @@ def make_absolute_paths(content):
         if not x['url'] or has_scheme.match(x['url']):
             continue
 
-        if not x['root'].endswith('/'):
-            x['root'] += '/'
+        root = str(x['root'])
+        if not root.endswith('/'):
+            root += '/'
 
         occur_pattern = '''(["|']{0}.*?["|'])'''
         occurences = re.findall(occur_pattern.format(x['url']), content)
         occurences = list(set(occurences))  # Remove dups
         for occur in occurences:
             content = content.replace(occur, '"%s"' % (
-                                      pathname2fileurl(x['root']) +
+                                      pathname2fileurl(root) +
                                       occur[1 + len(x['url']): -1]))
 
 


### PR DESCRIPTION
Django 3.x uses `pathlib.PosixPath` by default in `settings.py` for `MEDIA_ROOT` and `STATIC_ROOT`. This patch enables the `make_absolute_paths` method to correctly process those paths.