### PR TITLE
Fix AttributeError when using pathlib in settings

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -293,8 +293,8 @@ def make_absolute_paths(content):
         if not x['url'] or has_scheme.match(x['url']):
             continue
 
-        if not x['root'].endswith('/'):
-            x['root'] += '/'
+        if not str(x['root']).endswith('/'):
+            x['root'] = f"{x['root']}/"
 
         occur_pattern = '''(["|']{0}.*?["|'])'''
         occurences = re.findall(occur_pattern.format(x['url']), content)


### PR DESCRIPTION
Apparently newer Django versions defaults to pathlib for paths instead of strings which makes django-wkhtmltopdf to fail.

Fixes following error:

```
AttributeError: 'PosixPath' object has no attribute 'endswith'
```


