### PR TITLE
Change usage of smart_text to force_str for Django 4.0

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -8,7 +8,7 @@ import sys
 import shlex
 from tempfile import NamedTemporaryFile
 
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 try:
     from urllib.request import pathname2url
@@ -328,7 +328,7 @@ def render_to_temporary_file(template, context, request=None, mode='w+b',
             content = render(context)
         else:
             content = render(context, request)
-    content = smart_text(content)
+    content = smart_str(content)
     content = make_absolute_paths(content)
 
     try:


### PR DESCRIPTION
`django.utils.encoding.smart_text()` is removed in Django 4.0. This PR switches the usage of `smart_text` to its alias `force_str` which makes this package compatible with Django 4.0.