### PR TITLE
replace smart_text with force_str

### DIFF
--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -8,7 +8,7 @@ import sys
 import shlex
 from tempfile import NamedTemporaryFile
 
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_str
 
 try:
     from urllib.request import pathname2url
@@ -328,7 +328,7 @@ def render_to_temporary_file(template, context, request=None, mode='w+b',
             content = render(context)
         else:
             content = render(context, request)
-    content = smart_text(content)
+    content = force_str(content)
     content = make_absolute_paths(content)
 
     try:


### PR DESCRIPTION
replace `smart_text` with `force_str` since `smart_text` is removed in Django 4.0
https://docs.djangoproject.com/fr/4.0/releases/4.0/