### PR TITLE
Options with multiple values get split to send to subprocess

### DIFF
--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -59,6 +59,11 @@ class TestUtils(TestCase):
                                           file_name='file-name'),
                          ['--file-name', 'file-name',
                           '--heart', u'♥'])
+        self.assertEqual(_options_to_args(
+            custom_header='Authentication mytoken',
+            cookie='key1 value1'),
+            ['--cookie', 'key1', 'value1',
+             '--custom-header', 'Authentication', 'mytoken'])
 
     def test_wkhtmltopdf(self):
         """Should run wkhtmltopdf to generate a PDF"""

--- a/wkhtmltopdf/tests/tests.py
+++ b/wkhtmltopdf/tests/tests.py
@@ -64,6 +64,8 @@ class TestUtils(TestCase):
             cookie='key1 value1'),
             ['--cookie', 'key1', 'value1',
              '--custom-header', 'Authentication', 'mytoken'])
+        with self.assertRaises(ValueError):
+            _options_to_args(custom_header='Authentication')
 
     def test_wkhtmltopdf(self):
         """Should run wkhtmltopdf to generate a PDF"""

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -68,7 +68,9 @@ def _options_to_args(**options):
         if accepts_no_arguments:
             continue
         if is_multi_value_option:
-            flags.extend(value.split())
+            k, v = value.split(maxsplit=1)
+            flags.append(six.text_type(k))
+            flags.append(six.text_type(v))
         else:
             flags.append(six.text_type(value))
     return flags

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -46,7 +46,7 @@ NO_ARGUMENT_OPTIONS = ['--collate', '--no-collate', '-H', '--extended-help', '-g
                        '--enable-toc-back-links', '--footer-line', '--no-footer-line',
                        '--header-line', '--no-header-line', '--disable-dotted-lines',
                        '--disable-toc-links', '--verbose']
-MULTI_VALUE_OPTIONS = ['--custom-header', '--cookie']
+MULTI_VALUE_OPTIONS = ['--custom-header', '--cookie', '--post', '--replace']
 
 
 def _options_to_args(**options):

--- a/wkhtmltopdf/utils.py
+++ b/wkhtmltopdf/utils.py
@@ -46,6 +46,7 @@ NO_ARGUMENT_OPTIONS = ['--collate', '--no-collate', '-H', '--extended-help', '-g
                        '--enable-toc-back-links', '--footer-line', '--no-footer-line',
                        '--header-line', '--no-header-line', '--disable-dotted-lines',
                        '--disable-toc-links', '--verbose']
+MULTI_VALUE_OPTIONS = ['--custom-header', '--cookie']
 
 
 def _options_to_args(**options):
@@ -60,12 +61,16 @@ def _options_to_args(**options):
         formatted_flag = '--%s' % name if len(name) > 1 else '-%s' % name
         formatted_flag = formatted_flag.replace('_', '-')
         accepts_no_arguments = formatted_flag in NO_ARGUMENT_OPTIONS
+        is_multi_value_option = formatted_flag in MULTI_VALUE_OPTIONS
         if value is None or (value is False and accepts_no_arguments):
             continue
         flags.append(formatted_flag)
         if accepts_no_arguments:
             continue
-        flags.append(six.text_type(value))
+        if is_multi_value_option:
+            flags.extend(value.split())
+        else:
+            flags.append(six.text_type(value))
     return flags
 
 


### PR DESCRIPTION
When an option like --custom-header Authorization my-token is received this must be broken in to 3 strings to be given to subprocess.Popen

- 'custom-header'
- 'Authorization'
- 'my-token'

With the previous code where "Authorization my-token" was one string, Popen does not correctly pass both arguments with --custom-header. Consequently wkhtmltopdf ignores any --custom-header instruction sent to it from django-wkhtml. The problem can be seen by running these commands:

>>> import subprocess
>>> cmd = ['curl', '--dump-header output', 'https://api.github.com']
>>> subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
(b'', b"curl: option --dump-header output: is unknown\ncurl: try 'curl --help' for more information\n")

If you change the above command to be

cmd = ['curl', '--dump-header', 'output', 'https://api.github.com']

then the call works and makes a file called "output" containing header information.